### PR TITLE
experiment: call the global script from Vue

### DIFF
--- a/packages/core/src/global/global.ts
+++ b/packages/core/src/global/global.ts
@@ -1,1 +1,3 @@
-import '@gouvfr/dsfr/dist/dsfr.module.min';
+export default function () {
+  import('@gouvfr/dsfr/dist/dsfr.module.min');
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,1 +1,2 @@
+export { setAssetPath as bogus } from '@dtnum/core/components';
 export * from './components';


### PR DESCRIPTION
This should fix #42835 (ZenDesk).

**core**

I made the import of the other DS package a function as [described in the globalScripts docs](https://stenciljs.com/docs/config#globalscript).

This creates a call to the global scripts properly in the `components/index.js` file as such:

```JavaScript
export { setAssetPath, setPlatformOptions } from '@stencil/core/internal/client';
export { A as Accordion, FrAccordion, defineCustomElement as defineCustomElementFrAccordion } from './fr-accordion.js';
export { FrFooter, defineCustomElement as defineCustomElementFrFooter } from './fr-footer.js';
export { FrHeader, defineCustomElement as defineCustomElementFrHeader } from './fr-header.js';

function appGlobalScript () {
  import('./dsfr.module.min.js');
}

const globalScripts = appGlobalScript;

globalScripts();
```

However, that is not all since the generated Vue wrappers never directly load the `index.js` file but only import the individual component files. As such, the `globalScripts()` never gets called.

To get around this, I created a bogus export in the Vue index.ts file that forces a read of the `components/index.js` file, thus executing the global scripts and forcing your base DS to be imported.